### PR TITLE
 #157911916 refactor-update-request: Refactor update request to use ES6 spread operator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,6 @@
         "node": "current"
       }
     }]
-  ]
-  
+  ],
+  "plugins": ["transform-object-rest-spread"] 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -648,6 +648,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -882,6 +887,15 @@
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
         "babel-runtime": "6.26.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",

--- a/server/controllers/Requests.js
+++ b/server/controllers/Requests.js
@@ -1,5 +1,4 @@
 import validate from 'uuid-validate';
-import winston from 'winston';
 import pool from '../models/database';
 
 
@@ -33,7 +32,6 @@ class Requests {
           status: 'success',
         });
       }
-      winston.log('error', err);
       return res.status(404).json({
         message: 'No request for this user',
         status: 'fail',
@@ -69,7 +67,6 @@ class Requests {
           status: 'success',
         });
       }
-      winston.log('error', err);
       return res.status(404).json({
         message: 'You can\'t get a request that does not belong to you',
         status: 'fail',
@@ -91,7 +88,6 @@ class Requests {
     };
     pool.query(query, (err, response) => {
       if (err) {
-        winston.log('error', err);
         return res.status(500).json({
           data: { err },
           message: 'Request not created',
@@ -154,7 +150,6 @@ class Requests {
             status: 'success',
           });
         }
-        winston.log('error', error);
         return res.status(404).json({
           message: 'Request not found in the database',
           status: 'fail',

--- a/server/controllers/User.js
+++ b/server/controllers/User.js
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
-import winston from 'winston';
 import Authentication from '../helpers/Authentication';
 import pool from '../models/database';
 
@@ -35,7 +34,6 @@ class UserControllers {
     };
     pool.query(query, (err, response) => {
       if (err) {
-        winston.log('error', err);
         return res.status(500).json({
           message: 'User registration failed',
           status: 'error',
@@ -75,7 +73,6 @@ class UserControllers {
       values: [username],
     };
     pool.query(newQuery, (error, result) => {
-      winston.log('error', error);
       if (error) {
         return res.status(500).json({
           message: 'Login failed',

--- a/server/middleware/Validation.js
+++ b/server/middleware/Validation.js
@@ -53,6 +53,45 @@ class Validator {
     }
     return next();
   }
+  /**
+   * @static method to validate the data passed in the edit request
+   *
+   * @param {Object} req request object
+   * @param {Object} res response object
+   * @param {Function} next callback function
+   *
+   * @return {Object} response containing the status of validation
+   *
+   */
+  static editReqBody(req, res, next) {
+    const {
+      title,
+      details,
+    } = req.body;
+    if (!Number.isNaN(parseInt(title, 10))) {
+      return res.status(400).json({
+        message: 'Your title must start with alphabet',
+        status: 'fail',
+      });
+    }
+    if (details.length > 70) {
+      return res.status(400).json({
+        message: 'Please summarise the details to 70 characters',
+        status: 'fail',
+      });
+    } else if (!Number.isNaN(parseInt(details, 10))) {
+      return res.status(400).json({
+        message: 'Details must start with alphabets',
+        status: 'fail',
+      });
+    } else if (title.length > 50) {
+      return res.status(400).json({
+        message: 'Please enter a shorter title less than 50 characters',
+        status: 'fail',
+      });
+    }
+    return next();
+  }
 
   /**
    *@static: Method for checking users details before signing up a new user

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -27,7 +27,7 @@ const requestRoutes = (versionLink, app) => {
   app.put(
     `${versionLink}/users/requests/:requestId`,
     Authentication.verifyToken,
-    Validator.checkBody,
+    Validator.editReqBody,
     ValidateDatabase.checkUserRequest,
     ValidateDatabase.checkRequestStatus,
     Requests.editRequest,

--- a/server/tests/requests.test.js
+++ b/server/tests/requests.test.js
@@ -324,7 +324,7 @@ describe('Request controller', () => {
         .expect(200);
       expect(res.body.status).to.equal('success');
       expect(res.body).to.have.property('message');
-      expect(res.body.data).to.be.an('array');
+      expect(res.body.data).to.be.an('object');
       expect(res.body.message).to.equal('One request successfully retrieved from the database');
     });
   });
@@ -362,34 +362,6 @@ describe('Request controller', () => {
       expect(res.body).to.have.property('message');
       expect(res.body.message).to.equal('Invalid Id, please provide a valid uuid');
     });
-    it('should not edit request if title is not given', async () => {
-      const requestId = '1324dsg';
-      const res = await request(app)
-        .put(`/api/v1/users/requests/${requestId}`)
-        .set('Accept', 'application/json')
-        .set('token', userToken)
-        .send({
-          details: 'new new new request',
-        })
-        .expect(400);
-      expect(res.body.status).to.equal('fail');
-      expect(res.body).to.have.property('message');
-      expect(res.body.message).to.equal('Title is required to post a request');
-    });
-    it('should not edit request if details is not given', async () => {
-      const requestId = '1324dsg';
-      const res = await request(app)
-        .put(`/api/v1/users/requests/${requestId}`)
-        .set('Accept', 'application/json')
-        .set('token', userToken)
-        .send({
-          title: 'new new new request',
-        })
-        .expect(400);
-      expect(res.body.status).to.equal('fail');
-      expect(res.body).to.have.property('message');
-      expect(res.body.message).to.equal('Details of the request is required to post a request');
-    });
     it('should not edit request that doesn\'t belong to you', async () => {
       const requestId = 'd5043ca9-ed83-489c-9bc9-0b420577b7b5';
       const request2 = {
@@ -407,6 +379,43 @@ describe('Request controller', () => {
       expect(res.body).to.have.property('message');
       expect(res.body.message).to.equal('You can\'t edit a request that is not yours');
     });
+    it('should not edit a request that the title start with number', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
+      const request2 = {
+        title: '4 big fool',
+      };
+      const res = await request(app)
+        .put(`/api/v1/users/requests/${requestId}`)
+        .set('Accept', 'application/json')
+        .set('token', userToken)
+        .send(request2)
+        .expect(400);
+
+      expect(res.body).to.be.an('object');
+      expect(res.body.status).to.equal('fail');
+      expect(res.body).not.to.have.property('data');
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.equal('Your title must start with alphabet');
+    });
+    it('should not edit a request with title longer than 50', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
+      const request2 = {
+        title: 'hggjgj ffkkfj jkgjgf fkfkfkfg kdjkdkf djkfkdf kkfkf kdkdfkf kfkfjk kdffjkfk kjkfjkf kjfj k fk ffjf ',
+        details: 'New request for new request test',
+      };
+      const res = await request(app)
+        .put(`/api/v1/users/requests/${requestId}`)
+        .set('Accept', 'application/json')
+        .set('token', userToken)
+        .send(request2)
+        .expect(400);
+
+      expect(res.body).to.be.an('object');
+      expect(res.body.status).to.equal('fail');
+      expect(res.body).not.to.have.property('data');
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.equal('Please enter a shorter title less than 50 characters');
+    });
     it('should edit a user request', async () => {
       const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
       const res = await request(app)
@@ -422,6 +431,42 @@ describe('Request controller', () => {
       expect(res.body).to.have.property('message');
       expect(res.body.data).to.be.an('object');
       expect(res.body.message).to.equal('Request successfully updated');
+    });
+    it('should not edit a request with details starting with number', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
+      const request2 = {
+        details: '5 pigs are parturating',
+      };
+      const res = await request(app)
+        .put(`/api/v1/users/requests/${requestId}`)
+        .set('Accept', 'application/json')
+        .set('token', userToken)
+        .send(request2)
+        .expect(400);
+
+      expect(res.body).to.be.an('object');
+      expect(res.body.status).to.equal('fail');
+      expect(res.body).not.to.have.property('data');
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.equal('Details must start with alphabets');
+    });
+    it('should not edit a request with longer details', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
+      const request2 = {
+        details: 'hfjjfhd  jsjhhhhhhhhh jf fjhfj fjhfj fhf hfjjhjhhhhhhhhhhh hhhhhhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhh hhhhhh hhhhhh hhhhhhh',
+      };
+      const res = await request(app)
+        .put(`/api/v1/users/requests/${requestId}`)
+        .set('Accept', 'application/json')
+        .set('token', userToken)
+        .send(request2)
+        .expect(400);
+
+      expect(res.body).to.be.an('object');
+      expect(res.body.status).to.equal('fail');
+      expect(res.body).not.to.have.property('data');
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.equal('Please summarise the details to 70 characters');
     });
     it('should not edit a user request that the admin has approved or rejected', async () => {
       const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e45';

--- a/server/tests/requests.test.js
+++ b/server/tests/requests.test.js
@@ -95,7 +95,7 @@ describe('Request controller', () => {
     });
     it('should not post a request with title longer than 50', async () => {
       const request2 = {
-        title: 'hggjgj ffkkfj jkgjgf fkfkfkfg kdjkdkf djkfkdf kkfkf kdkdfkf kfkfjk kdffjkfk kjkfjkf kjfj k fk ffjf ',
+        title: 'This title will be long. Then it will become longer. Oh it it becoming longer. It is growing longer, long, longer, longest. It is about to reach the limit, but not yet. Oh my God, It has reached the limit ',
         details: 'New request for new request test',
       };
       const res = await request(app)
@@ -167,7 +167,7 @@ describe('Request controller', () => {
     it('should not post a request with longer details', async () => {
       const request2 = {
         title: 'big bowl',
-        details: 'hfjjfhd  jsjhhhhhhhhh jf fjhfj fjhfj fhf hfjjhjhhhhhhhhhhh hhhhhhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhh hhhhhh hhhhhh hhhhhhh',
+        details: 'This details will be long. Then it will become longer. Oh it it becoming longer. It is growing longer, long, longer, longest. It is about to reach the limit, but not yet. Oh my God, It has reached the limit',
       };
       const res = await request(app)
         .post('/api/v1/users/requests')
@@ -400,7 +400,7 @@ describe('Request controller', () => {
     it('should not edit a request with title longer than 50', async () => {
       const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
       const request2 = {
-        title: 'hggjgj ffkkfj jkgjgf fkfkfkfg kdjkdkf djkfkdf kkfkf kdkdfkf kfkfjk kdffjkfk kjkfjkf kjfj k fk ffjf ',
+        title: 'This title will be long. Then it will become longer. Oh it it becoming longer. It is growing longer, long, longer, longest. It is about to reach the limit, but not yet. Oh my God, It has reached the limit ',
         details: 'New request for new request test',
       };
       const res = await request(app)
@@ -453,7 +453,7 @@ describe('Request controller', () => {
     it('should not edit a request with longer details', async () => {
       const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e42';
       const request2 = {
-        details: 'hfjjfhd  jsjhhhhhhhhh jf fjhfj fjhfj fhf hfjjhjhhhhhhhhhhh hhhhhhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhhhh hhhhhhhh hhhhhhh hhhhhh hhhhhh hhhhhhh',
+        details: 'This details will be long. Then it will become longer. Oh it it becoming longer. It is growing longer, long, longer, longest. It is about to reach the limit, but not yet. Oh my God, It has reached the limit',
       };
       const res = await request(app)
         .put(`/api/v1/users/requests/${requestId}`)


### PR DESCRIPTION
#### What does this PR do?
- Refactor the update method in the request controller to use ES6 object spread 

#### Description of Task to be completed?
- Users don't need to supply both details and title to edit a request, they can supply just one

#### How should this be manually tested?
- Clone this repository
- navigate to the ```maintenace-tracker-app```  directory
- run npm install
- create a .env file at the root of the project following the guide from ```.env.example``` file found at the root of this repository and setup your port
- run ```npm run start```
- launch postman and send a POST request to ```localhost:'your port'/api/v1/auth/login``` or ```/auth/signup``` to login or create a new user or contact me for admin login
- Follow the guide on readme to test each endpoint

#### What are the relevant pivotal tracker stories?
 #157911916