### PR TITLE
#158458119 Reset a non pending request

### DIFF
--- a/server/middleware/ValidateDatabase.js
+++ b/server/middleware/ValidateDatabase.js
@@ -214,6 +214,37 @@ class ValidateDatabase {
     });
     return null;
   }
+  /**
+   * @static: Method for checking a pending request
+   *
+   * @param {object} req request object
+   * @param {object} res response object
+   * @param {function} done callback function
+   */
+  static checkPending(req, res, done) {
+    const { requestId } = req.params;
+    if (validate(requestId) === false) {
+      winston.log('error', 'Invalid Id, please provide a valid uuid');
+      return res.status(400).json({
+        message: 'Invalid Id, please provide a valid uuid',
+        status: 'error',
+      });
+    }
+    const newQuery = {
+      text: 'SELECT * FROM requests WHERE request_id = $1 AND currentStatus = $2',
+      values: [requestId, 'pending'],
+    };
+    pool.query(newQuery, (err, result) => {
+      if (result.rows[0]) {
+        return res.status(405).json({
+          message: 'This is a pending request, you can\'t reset a pending request',
+          status: 'fail',
+        });
+      }
+      return done();
+    });
+    return null;
+  }
 }
 
 export default ValidateDatabase;

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -34,6 +34,14 @@ const adminRoutes = (versionLink, app) => {
     ValidateDatabase.checkApproved,
     RequestController.resolveRequest,
   );
+  app.put(
+    `${versionLink}/requests/:requestId/reset`,
+    Authentication.verifyToken,
+    isAdmin,
+    ValidateDatabase.checkRequestId,
+    ValidateDatabase.checkPending,
+    RequestController.resetRequest,
+  );
 };
 
 export default adminRoutes;

--- a/server/tests/requestsadmin.test.js
+++ b/server/tests/requestsadmin.test.js
@@ -209,10 +209,6 @@ describe('Request controller', () => {
         .put(`/api/v1/requests/${requestId}/resolve`)
         .set('Accept', 'application/json')
         .set('token', userToken)
-        .send({
-          title: 'New edited request',
-          details: 'Latest edited',
-        })
         .expect(403);
       expect(res.body).to.have.a.property('message');
       expect(res.body.message).to.equal('You are not authorized to access this resources');
@@ -250,6 +246,64 @@ describe('Request controller', () => {
       expect(res.body.data).to.be.an('object');
       expect(res.body).to.have.a.property('message');
       expect(res.body.message).to.equal('Request has been successfully resolved');
+      expect(res.body.status).to.equal('success');
+    });
+  });
+  describe('PUT /api/v1/requests/:requestId/reset', () => {
+    it('should not reset a request with invalid id', async () => {
+      const requestId = '1424fff';
+      const res = await request(app)
+        .put(`/api/v1/requests/${requestId}/reset`)
+        .set('Accept', 'application/json')
+        .set('token', adminToken)
+        .expect(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('message');
+      expect(res.body.message).to.equal('Invalid Id, please provide a valid uuid');
+      expect(res.body.status).to.equal('fail');
+    });
+    it('should not reset a request when user not authenticated', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e45';
+      const res = await request(app)
+        .put(`/api/v1/requests/${requestId}/reset`)
+        .set('Accept', 'application/json')
+        .expect(401);
+      expect(res.body).to.have.a.property('message');
+      expect(res.body.message).to.equal('Please login with your username and password');
+      expect(res.body).not.to.have.a.property('data');
+    });
+    it('should not reset a request if user is not an admin', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e45';
+      const res = await request(app)
+        .put(`/api/v1/requests/${requestId}/reset`)
+        .set('Accept', 'application/json')
+        .set('token', userToken)
+        .expect(403);
+      expect(res.body).to.have.a.property('message');
+      expect(res.body.message).to.equal('You are not authorized to access this resources');
+      expect(res.body.status).to.equal('fail');
+    });
+    it('should not reset a pending request', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e49';
+      const res = await request(app)
+        .put(`/api/v1/requests/${requestId}/reset`)
+        .set('Accept', 'application/json')
+        .set('token', adminToken)
+        .expect(405);
+      expect(res.body).to.have.a.property('message');
+      expect(res.body.message).to.equal('This is a pending request, you can\'t reset a pending request');
+      expect(res.body.status).to.equal('fail');
+    });
+    it('should reset a non pending request', async () => {
+      const requestId = '0ce529f4-8854-41ec-b67c-fbcb4e716e55';
+      const res = await request(app)
+        .put(`/api/v1/requests/${requestId}/reset`)
+        .set('Accept', 'application/json')
+        .set('token', adminToken)
+        .expect(200);
+      expect(res.body.data).to.be.an('object');
+      expect(res.body).to.have.a.property('message');
+      expect(res.body.message).to.equal('The status of this request has been sucessfully reset');
       expect(res.body.status).to.equal('success');
     });
   });


### PR DESCRIPTION
#### What does this PR do?
Enable method to reset a request status in case an admin make a mistake

#### Description of Task to be completed?
Allows users to update password
Refactor validation for user registration and loggin a new request

#### How should this be manually tested?
- Clone this repository
- navigate to the ```maintenace-tracker-app```  directory
- run npm install
- create a .env file at the root of the project following the guide from ```.env.example``` file found at the root of this repository and setup your port
- run ```npm run start```
- launch postman and send a POST request to ```localhost:'your port'/api/v1/auth/login``` to login , contact me for admin login
- copy the received token and insert into the header before sending a PUT request to ```localhost:PORT/api/v1/requests/:requestId/reset``` 

- To run test,  run ```npm test``` in your terminal

#### What are the relevant pivotal tracker stories?
#158458119



