### PR TITLE
#158235669: Allow admin to change a user role

### DIFF
--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -2,6 +2,7 @@ import RequestController from '../controllers/Admin';
 import Authentication from '../helpers/Authentication';
 import ValidateDatabase from '../middleware/ValidateDatabase';
 import isAdmin from '../middleware/isAdmin';
+import UserControllers from '../controllers/User';
 
 const adminRoutes = (versionLink, app) => {
   app.get(
@@ -47,6 +48,12 @@ const adminRoutes = (versionLink, app) => {
     ValidateDatabase.checkRequestId,
     ValidateDatabase.checkPending,
     RequestController.resetRequest,
+  );
+  app.put(
+    `${versionLink}/user/role/:userId/update`,
+    Authentication.verifyToken,
+    isAdmin,
+    UserControllers.updateUserRole,
   );
 };
 

--- a/server/tests/requestsadmin.test.js
+++ b/server/tests/requestsadmin.test.js
@@ -307,36 +307,4 @@ describe('Request controller', () => {
       expect(res.body.status).to.equal('success');
     });
   });
-  describe('GET /api/v1/users', () => {
-    it('should not get lists of users if user is not login', async () => {
-      const res = await request(app)
-        .get('/api/v1/users')
-        .set('Accept', 'application/json')
-        .expect(401);
-      expect(res.body).to.have.a.property('message');
-      expect(res.body.message).to.equal('Please login with your username and password');
-      expect(res.body).not.to.have.a.property('data');
-    });
-    it('should not get list of all users if user is not an admin', async () => {
-      const res = await request(app)
-        .get('/api/v1/users')
-        .set('Accept', 'application/json')
-        .set('token', userToken)
-        .expect(403);
-      expect(res.body).to.have.a.property('message');
-      expect(res.body.message).to.equal('You are not authorized to access this resources');
-      expect(res.body.status).to.equal('fail');
-    });
-    it('should get list of all users for admin', async () => {
-      const res = await request(app)
-        .get('/api/v1/users')
-        .set('Accept', 'application/json')
-        .set('token', adminToken)
-        .expect(200);
-      expect(res.body.data).to.be.an('array');
-      expect(res.body).to.have.a.property('message');
-      expect(res.body.message).to.equal('Users successfully retrieved from the database');
-      expect(res.body.status).to.equal('success');
-    });
-  });
 });

--- a/server/tests/userpassreset.test.js
+++ b/server/tests/userpassreset.test.js
@@ -57,6 +57,42 @@ describe('POST /api/v1/auth/passwordreset', () => {
     expect(res.body.status).to.equal('success');
   });
 });
+describe('GET /api/v1/auth/resetpassword/:id/:token', () => {
+  it('should not decode payload if id is invalid not supplied', async () => {
+    const id = '55';
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ4YTY5OGEwLTE2NDEtNWFjYS1iYzFiLWRlOWIxYTQ4MmVlMSIsImVtYWlsIjoic2p1bGlldDA3QGdtYWlsLmNvbSIsInVzZXJuYW1lIjoianVsaWV0IiwiaWF0IjoxNTI5NTI4NTA0LCJleHAiOjE1Mjk1MzIxMDR9.9LGyxN-_yehlqBQ3XKOhWAoCvLbKpX8RyKjW3mqgicM';
+    const res = await request(app)
+      .get(`/api/v1/auth/resetpassword/${id}/${token}`)
+      .set('Accept', 'application/json')
+      .expect(400);
+    expect(res.body).to.have.a.property('message');
+    expect(res.body.message).to.equal('Invalid id, please use a valid user uuid');
+    expect(res.body.status).to.equal('fail');
+  });
+  it('should not decode payload if user not found', async () => {
+    const id = '48a698a0-1641-5aca-bc1b-de9b1a482ee9';
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ4YTY5OGEwLTE2NDEtNWFjYS1iYzFiLWRlOWIxYTQ4MmVlMSIsImVtYWlsIjoic2p1bGlldDA3QGdtYWlsLmNvbSIsInVzZXJuYW1lIjoianVsaWV0IiwiaWF0IjoxNTI5NTI4NTA0LCJleHAiOjE1Mjk1MzIxMDR9.9LGyxN-_yehlqBQ3XKOhWAoCvLbKpX8RyKjW3mqgicM';
+    const res = await request(app)
+      .get(`/api/v1/auth/resetpassword/${id}/${token}`)
+      .set('Accept', 'application/json')
+      .expect(404);
+    expect(res.body).to.have.a.property('message');
+    expect(res.body.message).to.equal('User not found in the database');
+    expect(res.body.status).to.equal('fail');
+  });
+  it('should decode payload if id and token are valid', async () => {
+    const id = '48a698a0-1641-5aca-bc1b-de9b1a482ee1';
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ4YTY5OGEwLTE2NDEtNWFjYS1iYzFiLWRlOWIxYTQ4MmVlMSIsImVtYWlsIjoic2p1bGlldDA3QGdtYWlsLmNvbSIsInVzZXJuYW1lIjoianVsaWV0IiwiaWF0IjoxNTI5NTI4NTA0LCJleHAiOjE1Mjk1MzIxMDR9.9LGyxN-_yehlqBQ3XKOhWAoCvLbKpX8RyKjW3mqgicM';
+    const res = await request(app)
+      .get(`/api/v1/auth/resetpassword/${id}/${token}`)
+      .set('Accept', 'application/json')
+      .expect(200);
+    expect(res.body).to.have.a.property('message');
+    expect(res.body.data).to.have.a.property('payload');
+    expect(res.body.message).to.equal('Token successfully decoded, please enter a new password in the provided form');
+    expect(res.body.status).to.equal('success');
+  });
+});
 describe('POST /api/v1/auth/resetpassword', () => {
   it('should not reset password if token is not supplied', async () => {
     const res = await request(app)
@@ -95,6 +131,34 @@ describe('POST /api/v1/auth/resetpassword', () => {
       .expect(400);
     expect(res.body).to.have.a.property('message');
     expect(res.body.message.errors.password[0]).to.equal('The password field is required.');
+    expect(res.body.status).to.equal('fail');
+  });
+  it('should not reset password if id is invalid', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/resetpassword')
+      .set('Accept', 'application/json')
+      .send({
+        id: '48',
+        token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ4YTY5OGEwLTE2NDEtNWFjYS1iYzFiLWRlOWIxYTQ4MmVlMSIsImVtYWlsIjoic2p1bGlldDA3QGdtYWlsLmNvbSIsInVzZXJuYW1lIjoianVsaWV0IiwiaWF0IjoxNTI5NTI4NTA0LCJleHAiOjE1Mjk1MzIxMDR9.9LGyxN-_yehlqBQ3XKOhWAoCvLbKpX8RyKjW3mqgicM',
+        password: 'september123',
+      })
+      .expect(400);
+    expect(res.body).to.have.a.property('message');
+    expect(res.body.message).to.equal('Invalid id, please use a valid user uuid');
+    expect(res.body.status).to.equal('fail');
+  });
+  it('should not reset password if token is invalid', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/resetpassword')
+      .set('Accept', 'application/json')
+      .send({
+        id: '48a698a0-1641-5aca-bc1b-de9b1a482ee1',
+        token: 'eyJhbGciOiJIUzI1NiIsInR5cCIkpXVCJ9.eyJpZCI6IjQ4YTY5OGEwLTE2EtNWFjYS1iYzFiLWRlOWIxYTQ4MmVlMSIsImVtlsIjoic2p1bGlldDA3QGdtYWlsLmNvbSIsInVzZXJuYW1lIjoianVsaWV0IiwiaWF0IjoxNTI5NTI4NTA0LCJleHAiOjE1Mjk1MzIxMDR9.9LGyxN-_yehlqBQ3XKOhWAoCvLbKpX8RyKjW3mqgicM',
+        password: 'september123',
+      })
+      .expect(400);
+    expect(res.body).to.have.a.property('message');
+    expect(res.body.message).to.equal('Invalid token, please use a valid token');
     expect(res.body.status).to.equal('fail');
   });
   it('should reset password if token, id and password are supplied', async () => {


### PR DESCRIPTION
#### What does this PR do?
set up a method to update user role by admin

#### Description of Task to be completed?
Update a user or admin role

#### How should this be manually tested?
- Clone this repository
- navigate to the ```maintenace-tracker-app```  directory
- run npm install
- create a .env file at the root of the project following the guide from ```.env.example``` file found at the root of this repository and setup your port
- run ```npm run start```
- launch postman and login as an admin,
- send a PUT request to ```localhost:'your port'/api/v1/user/role/:userId/update```
- To run test,  run ```npm run test``` in your terminal

#### What are the relevant pivotal tracker stories?
#158235669